### PR TITLE
Remove some potential dead-ends in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Custom firmware for a 3-key + rotary encoder macropad (https://hackaday.io/proje
 `$ make bin`
 
 ### compile & flash to pad:
-- if on original firmware: connect P1.5 (pin 3) to GND (pin 14) and connect USB
+- if on original firmware:
+  - open the keypad and locate the 16-pin IC next to two of the key mounts
+  - connect P1.5 (pin 3) to GND (pin 14) and connect USB
   - if this doesn't work, try the CH552 default of connecting 3.6 (pin 12) to 3v3 (pin 16)
 - if on this firmware: press key1 while connecting USB
 - `$ make flash`

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Custom firmware for a 3-key + rotary encoder macropad (https://hackaday.io/proje
 `$ make bin`
 
 ### compile & flash to pad:
-- if on original firmware: connect P1.5 to GND and connect USB
-  - if this doesn't work, try the CH552 default of connecting 3.6 to 3v3
+- if on original firmware: connect P1.5 (pin 3) to GND (pin 14) and connect USB
+  - if this doesn't work, try the CH552 default of connecting 3.6 (pin 12) to 3v3 (pin 16)
 - if on this firmware: press key1 while connecting USB
 - `$ make flash`
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Custom firmware for a 3-key + rotary encoder macropad (https://hackaday.io/proje
 - `$ make flash`
 
 ### configure keys:
-1. `$ isp55e0 --data-dump flashdata.bin`
-2. edit first 6 bytes of this binary (3 keys, plus 3 for the knob), and write it back:
-3. `$ isp55e0 --data-flash flashdata.bin`
+1. dump the current build: `$ isp55e0 --data-dump flashdata.bin`
+2. edit the first 6 bytes of this binary to the [key codes](./include/usb_conkbd.h) you want to use for:
+  - each of the three keys,
+  - the knob switch,
+  - turning the knob clockwise, then
+  - turning the knob counterclockwise
+3. write it back: `$ isp55e0 --data-flash flashdata.bin`

--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ Custom firmware for a 3-key + rotary encoder macropad (https://hackaday.io/proje
 
 ### compile & flash to pad:
 - if on original firmware:
-  - open the keypad and locate the 16-pin IC next to two of the key mounts
-  - connect P1.5 (pin 3) to GND (pin 14) and connect USB
-  - if this doesn't work, try the CH552 default of connecting 3.6 (pin 12) to 3v3 (pin 16)
+    - open the keypad and locate the 16-pin IC next to two of the key mounts
+    - connect P1.5 (pin 3) to GND (pin 14) and connect USB
+    - if this doesn't work, try the CH552 default of connecting 3.6 (pin 12) to 3v3 (pin 16)
 - if on this firmware: press key1 while connecting USB
 - `$ make flash`
 
 ### configure keys:
 1. dump the current build: `$ isp55e0 --data-dump flashdata.bin`
 2. edit the first 6 bytes of this binary to the [key codes](./include/usb_conkbd.h) you want to use for:
-  - each of the three keys,
-  - the knob switch,
-  - turning the knob clockwise, then
-  - turning the knob counterclockwise
+    - each of the three keys,
+    - the knob switch,
+    - turning the knob clockwise, then
+    - turning the knob counterclockwise
 3. write it back: `$ isp55e0 --data-flash flashdata.bin`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Custom firmware for a 3-key + rotary encoder macropad (https://hackaday.io/proje
 
 ### compile & flash to pad:
 - if on original firmware: connect P1.5 to GND and connect USB
+  - if this doesn't work, try the CH552 default of connecting 3.6 to 3v3
 - if on this firmware: press key1 while connecting USB
 - `$ make flash`
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ Custom firmware for a 3-key + rotary encoder macropad (https://hackaday.io/proje
 ### compile & flash to pad:
 - if on original firmware:
     - open the keypad and locate the 16-pin IC next to two of the key mounts
-    - connect P1.5 (pin 3) to GND (pin 14) and connect USB
+    - connect P1.5 (pin 3 [on the IC][wp-dip]) to GND (pin 14) and connect USB
     - if this doesn't work, try the CH552 default of connecting 3.6 (pin 12) to 3v3 (pin 16)
 - if on this firmware: press key1 while connecting USB
 - `$ make flash`
+
+[wp-dip]: https://en.wikipedia.org/wiki/Dual_in-line_package#Orientation_and_lead_numbering "Wikipedia's description of how to count pins on this kind of IC"
 
 ### configure keys:
 1. dump the current build: `$ isp55e0 --data-dump flashdata.bin`


### PR DESCRIPTION
some of the things changed here are things i got stuck on, some are things i think others might. i had to look up the datasheet to work out what pins to bridge

i also wanted to specify what order the keys are numbered in, but i haven't been able to successfully boot into bootloader mode yet, so i've not been able to check